### PR TITLE
UHM-4354: Move locations into Initializer configuration

### DIFF
--- a/configuration/locations/locations.csv
+++ b/configuration/locations/locations.csv
@@ -1,0 +1,6 @@
+UUID,Void/Retire,Name,Description,Parent,Tag|Archives Location,Tag|Check-In Location,Tag|Consult Note Location,Tag|Dispensing Location,Tag|ED Triage Location,Tag|Maternal and Child Location,Tag|Medical Record Location,Tag|Mental Health Location,Tag|Program Location,Tag|Registration Location,Tag|Visit Location,Tag|Vitals Location
+0561303b-9868-4a1d-933d-fe52ce1b8c9f,,Wellbody,Wellbody,,,,,,,,,,,,TRUE,
+b6733150-7426-11e5-a837-0800200c9a66,,Wellbody Clinic,Wellbody Clinic,Wellbody,TRUE,TRUE,TRUE,TRUE,,TRUE,TRUE,TRUE,TRUE,TRUE,,TRUE
+dac348b7-2ece-47ad-b80a-140fc6788706,,Wellbody MCH,Wellbody MCH,Wellbody,TRUE,TRUE,TRUE,TRUE,,TRUE,TRUE,TRUE,TRUE,TRUE,,TRUE
+074b2ab0-716a-11eb-8aa6-0242ac110002,,KGH,KGH,,,,,,,,,,,,TRUE,
+2bcb9215-8cd6-11eb-b7be-0242ac110002,,KGH Triage,KGH Triage,KGH,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,,TRUE

--- a/configuration/pih/pih-config-sierraLeone-kgh.json
+++ b/configuration/pih/pih-config-sierraLeone-kgh.json
@@ -5,19 +5,7 @@
   "site": "KGH",
 
   "locationTags": {
-    "Visit Location": ["KGH"],
-    "Archives Location": ["KGH Triage"],
-    "Check-In Location": ["KGH Triage"],
-    "Consult Note Location": ["KGH Triage"],
-    "Dispensing Location": ["KGH Triage"],
-    "ED Triage Location": ["KGH Triage"],
-    "Login Location": ["KGH Triage"],
-    "Maternal and Child Location": ["KGH Triage"],
-    "Medical Record Location": ["KGH Triage"],
-    "Mental Health Location": ["KGH Triage"],
-    "Program Location": ["KGH Triage"],
-    "Registration Location": ["KGH Triage"],
-    "Vitals Location": ["KGH Triage"]
+    "Login Location": ["KGH Triage"]
   },
 
   "components": [

--- a/configuration/pih/pih-config-sierraLeone-wellbody.json
+++ b/configuration/pih/pih-config-sierraLeone-wellbody.json
@@ -8,18 +8,7 @@
   "site": "WELLBODY",
 
   "locationTags": {
-    "Visit Location": ["Wellbody"],
-    "Archives Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Check-In Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Consult Note Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Dispensing Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Login Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Maternal and Child Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Medical Record Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Mental Health Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Program Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Registration Location": ["Wellbody Clinic", "Wellbody MCH"],
-    "Vitals Location": ["Wellbody Clinic", "Wellbody MCH"]
+    "Login Location": ["Wellbody Clinic", "Wellbody MCH"]
   },
 
   "components": [


### PR DESCRIPTION
https://pihemr.atlassian.net/browse/UHM-4354

There is a slight functional change here. Previously, all of the location tags were assigned based on the server site configuration. For `pih-config-kgh.json`, only tags for KGH locations were tagged, likewise with the Wellbody config and Wellbody locations. Now all location tags are always assigned to both KGH and Wellbody locations, except Login Location. This is consistent with our location tagging in Mexico.