### PR TITLE
SL-595 configure columns for triage queue tables

### DIFF
--- a/configuration/frontend/config.json
+++ b/configuration/frontend/config.json
@@ -283,7 +283,65 @@
       "defaultTransitionStatus": "${concept.inService.uuid}"
     },
     "visitQueueNumberAttributeUuid": "",
-    "defaultFacilityUrl": ""
+    "defaultFacilityUrl": "",
+    "tablesConfig": {
+      "columnDefinitions": [
+        {
+          "id": "patient-name",
+          "columnType": "patient-name-column"
+        },
+        {
+          "id": "emr-id",
+          "columnType": "patient-identifier-column",
+          "config": {
+            "identifierType": "${patientIdentifierType.kghEmrId.uuid}"
+          },
+          "header": "EMR ID"
+        },
+        {
+          "id": "age",
+          "columnType": "patient-age-column"
+        },
+        {
+          "id": "wait-time",
+          "columnType": "wait-time-column"
+        },
+        {
+          "id": "in-service-time",
+          "columnType": "wait-time-column",
+          "header": "Time in service"
+        },
+        {
+          "id": "check-in-date",
+          "columnType": "visit-start-time-column",
+          "header": "Check-in date"
+        },
+        {
+          "id": "actions",
+          "columnType": "actions-column"
+        }
+      ],
+      "tableDefinitions": [
+        {
+          "columns": ["patient-name", "emr-id", "age", "check-in-date", "wait-time", "actions"],
+          "appliedTo": [
+            {
+              "queue": "${queue.triage.uuid}",
+              "status": "${concept.waiting.uuid}"
+            }
+          ]
+        },
+        {
+          "columns": ["patient-name", "emr-id", "age", "in-service-time", "actions"],
+          "appliedTo": [
+            {
+              "queue": "${queue.triage.uuid}",
+              "status": "${concept.inService.uuid}"
+            }
+          ]
+        }
+      ]
+    }
   }
 }
 

--- a/constants.yml
+++ b/constants.yml
@@ -63,3 +63,6 @@ concept:
     uuid: "167408AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   waitingForTransfer:
     uuid: "d639afb2-8f85-4774-a623-e6e051cda9c6"
+queue:
+  triage:
+    uuid: "3113f164-68f0-11ee-ab8d-0242ac120002"


### PR DESCRIPTION
Configuration of columns of the triage queue, as specified here:
https://pihemr.atlassian.net/wiki/spaces/MCPS/pages/3009151011/Queue+Table+Requirements

![image](https://github.com/PIH/openmrs-config-pihsl/assets/509602/6bedb8bd-5afb-4f3f-b9c5-c708a1641315)