### PR TITLE
UHM-8240 reorder the ward app workspace action menu icons

### DIFF
--- a/configuration/frontend/config.json
+++ b/configuration/frontend/config.json
@@ -403,7 +403,19 @@
         "id": "maternal-ward"
       }
     ],
-    "hideWorkspaceVitalsLinks": true
+    "hideWorkspaceVitalsLinks": true,
+    "extensionSlots": {
+      "action-menu-ward-patient-items-slot": {
+        "order": [
+          "ward-patient-action-button",
+          "o2-visit-summary-workspace-siderail-button",
+          "ward-inpatient-notes-form-action-button",
+          "transfer-swap-patient-siderail-button",
+          "patient-discharge-siderail-button",
+          "clinical-forms-workspace-siderail-button"
+        ]
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The O2 visit summary action menu button is slotted into the ward app workspace from openmrs-esm-pihemr. We want to re-order it so it appears below the patient chart icon.

![image](https://github.com/user-attachments/assets/08f49fe0-8bd6-47c0-bbd8-6a64d9d3030e)
