### PR TITLE
Revert "UHM-8242 change O3 appointments check-in button redirect URL"

### DIFF
--- a/configuration/frontend/config.json
+++ b/configuration/frontend/config.json
@@ -1,7 +1,7 @@
 {
   "@openmrs/esm-appointments-app": {
     "checkInButton": {
-      "customUrl": "${openmrsBase}/htmlformentryui/htmlform/enterHtmlFormWithSimpleUi.page?patientId=${patientUuid}&definitionUiResource=file:pih/htmlforms/checkin.xml&createVisit=true&returnUrl=${openmrsSpaBase}%2Fappointments"
+      "customUrl": "${openmrsBase}/htmlformentryui/htmlform/enterHtmlFormWithSimpleUi.page?patientId=${patientUuid}&definitionUiResource=file:pih/htmlforms/checkin.xml&createVisit=true&returnUrl=${openmrsSpaBase}%2Fhome%2Fappointments"
     },
     "patientIdentifierType": "KGHEMRID"
   },


### PR DESCRIPTION
Mounting the O3 apps into our own commons app doesn't work for the appointments app. I'm removing the left nav a different way instead. Reverting this change.

This reverts commit b6fecd61c214beae21d7673f446295854b2332ed.