### PR TITLE
Add ignoreStatusCodes to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
         customHeaders: '{"Accept": "application/json"}'
         retry: 60
         retryWait: 60000
+        ignoreStatusCodes: 400
 
     - name: Deploy to Gladi
       uses: fjogeleit/http-request-action@v1
@@ -51,3 +52,4 @@ jobs:
         customHeaders: '{"Accept": "application/json"}'
         retry: 60
         retryWait: 60000
+        ignoreStatusCodes: 400


### PR DESCRIPTION
Prevent a hang when a job is disabled in Bamboo.