### PR TITLE
SL-1334: limit the number of obs displayed on the Temperature widget

### DIFF
--- a/configuration/appframework/infant_dashboard_app.json
+++ b/configuration/appframework/infant_dashboard_app.json
@@ -316,6 +316,7 @@
       "showTime": true,
       "minValue": "35.9",
       "maxValue": "38",
+      "maxRecords": "5",
       "visitUrl": "/pihcore/visit/visit.page?patient={{patient.uuid}}&visit={{visit.uuid}}#/overview" ,
       "duringCurrentEnrollmentInProgram": "${program.infant.uuid}"
     }


### PR DESCRIPTION
I have used the same parameter name, maxRecords as it is already on other dashboard widgets.