### PR TITLE
SL-1381: Add line breaks to form fields in VIEW mode

### DIFF
--- a/configuration/pih/htmlforms/section-anc-followup.xml
+++ b/configuration/pih/htmlforms/section-anc-followup.xml
@@ -53,7 +53,6 @@
 
             #section-anc-followup fieldset p {
                 vertical-align: top;
-                display: inline-block;
                 float: none;
             }
 

--- a/configuration/pih/htmlforms/section-anc-intake.xml
+++ b/configuration/pih/htmlforms/section-anc-intake.xml
@@ -73,7 +73,6 @@
 
             #section-anc-intake fieldset p {
                 vertical-align: top;
-                display: inline-block;
                 float: none;
             }
 

--- a/configuration/pih/htmlforms/section-postnatal-followup.xml
+++ b/configuration/pih/htmlforms/section-postnatal-followup.xml
@@ -132,7 +132,6 @@
 
             #section-postnatal-followup fieldset p {
             vertical-align: top;
-            display: inline-block;
             float: none;
             }
 


### PR DESCRIPTION
The scheduled appointment look weird without line breaks in the ANC First Visit, ANC Follow-up, and Postnatal Follow-up forms. This PR adds those line breaks.

The CSS changes affect more than just the appointment fields, but I think the overall linebreaks elsewhere are desirable.

Before (ANC First Visit):
<img width="3168" height="1741" alt="Screenshot From 2026-08-06 13-50-36" src="https://github.com/user-attachments/assets/00bd22a6-7008-4829-b2b3-e5191a16d56a" />

After (ANC First Visit):
<img width="3168" height="1741" alt="Screenshot From 2026-08-06 14-38-29" src="https://github.com/user-attachments/assets/92de6912-6cfa-4176-aa9f-352b098266c8" />
